### PR TITLE
Reuse QUIC connection

### DIFF
--- a/examples/bookstore/go.mod
+++ b/examples/bookstore/go.mod
@@ -20,6 +20,8 @@ require (
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 )
 
+require github.com/quicsec/quicsec v0.0.0-20221007145901-d1186e9f4ed7
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -49,7 +51,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/quicsec/quicsec v0.0.0-20221007145901-d1186e9f4ed7 // indirect
 	github.com/rogpeppe/go-internal v1.6.2 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect


### PR DESCRIPTION
	Was implemented a singleton for http3.roudTripper. This allows connection be reused between requests.
	In previous version, the roundTripper were recreated in every call to quicsec.Do(). It was avoiding
	connections being cached.


Reference image tag: qsv-017