### PR TITLE
HTTP group by identity

### DIFF
--- a/auth/authManager.go
+++ b/auth/authManager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/quicsec/quicsec/config"
 	"github.com/quicsec/quicsec/identity"
+	"github.com/quicsec/quicsec/operations"
 	"github.com/quicsec/quicsec/operations/log"
 	"github.com/quicsec/quicsec/spiffeid"
 )
@@ -25,19 +26,6 @@ type VerifyOption interface {
 
 func (fn verifyOption) apply(config *verifyConfig) {
 	fn(config)
-}
-
-// IDFromCert extracts the SPIFFE ID from the URI SAN of the provided
-// certificate. It will return an an error if the certificate does not have
-// exactly one URI SAN with a well-formed SPIFFE ID.
-func IDFromCert(cert *x509.Certificate) (spiffeid.ID, error) {
-	switch {
-	case len(cert.URIs) == 0:
-		return spiffeid.ID{}, errors.New("certificate contains no URI SAN")
-	case len(cert.URIs) > 1:
-		return spiffeid.ID{}, errors.New("certificate contains more than one URI SAN")
-	}
-	return spiffeid.FromURI(cert.URIs[0])
 }
 
 // Verify verifies an X509-SVID chain using the X.509 bundle source. It
@@ -76,8 +64,7 @@ func Verify(certs []*x509.Certificate, opts ...VerifyOption) (spiffeid.ID, [][]*
 	}
 
 	leaf := certs[0]
-
-	id, err := IDFromCert(leaf)
+	id, err := identity.IDFromCert(leaf)
 	if err != nil {
 		return spiffeid.ID{}, nil, fmt.Errorf("could not get leaf SPIFFE ID: %s", err)
 	}
@@ -181,9 +168,21 @@ func CustomVerifyPeerCertificate(rawCerts [][]byte, verifiedChains [][]*x509.Cer
 		rv := identity.VerifyIdentity(uri.String())
 		if rv {
 			authLogger.Info("verify peer certificate", "authorized", "yes", "URI", uri.String())
+			if config.GetServerSideFlag() {
+				operations.AuthzConnectiontServerId.WithLabelValues(config.GetIdentity().String(), uri.String(), "authorized").Inc()
+			} else {
+				operations.AuthzConnectiontClientId.WithLabelValues(config.GetIdentity().String(), uri.String(), "authorized").Inc()
+			}
 			return nil
 		} else {
+			if config.GetServerSideFlag() {
+				operations.AuthzConnectiontServerId.WithLabelValues(config.GetIdentity().String(), uri.String(), "unauthorized").Inc()
+			} else {
+				operations.AuthzConnectiontClientId.WithLabelValues(config.GetIdentity().String(), uri.String(), "unauthorized").Inc()
+			}
+
 			authLogger.Info("verify peer certificate", "authorized", "no", "URI", uri.String())
+
 		}
 	}
 

--- a/config/configManager.go
+++ b/config/configManager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/logr"
 	"github.com/quicsec/quicsec/operations/log"
+	"github.com/quicsec/quicsec/spiffeid"
 	"github.com/spf13/viper"
 )
 
@@ -25,6 +26,7 @@ type Config struct {
 	Metrics  MetricsConfigs
 	Certs    CertificatesConfigs
 	Security SecurityConfigs
+	Local    LocalConfigs
 }
 
 // opsManager - logs
@@ -84,6 +86,15 @@ type MtlsConfig struct {
 
 type AuthzConfigs struct {
 	SpiffeID []string
+}
+
+// LocalConfigs
+type LocalConfigs struct {
+	// Identity (x509)
+	Identity spiffeid.ID
+
+	// Server=1/Client=0
+	ServerSideFlag bool
 }
 
 // AuthzConfig struct to parse the authz json file
@@ -154,6 +165,22 @@ func SetMtlsEnable(flag bool) {
 
 func SetLastAuthRules(spiffeURI []string) {
 	globalConfig.Security.Mtls.Authz.SpiffeID = spiffeURI
+}
+
+func GetIdentity() spiffeid.ID {
+	return globalConfig.Local.Identity
+}
+
+func SetIdentity(id spiffeid.ID) {
+	globalConfig.Local.Identity = id
+}
+
+func GetServerSideFlag() bool {
+	return globalConfig.Local.ServerSideFlag
+}
+
+func SetServerSideFlag(f bool) {
+	globalConfig.Local.ServerSideFlag = f
 }
 
 func (c Config) ShowConfig() {

--- a/conn/connManager.go
+++ b/conn/connManager.go
@@ -39,7 +39,7 @@ func ListenAndServe(addr string, handler http.Handler) error {
 	// init logger, preshared dump and tracers (metrics and qlog)
 	keyLog, opsTracer := ops.OperationsInit()
 	connLogger := log.LoggerLgr.WithName(log.ConstConnManager)
-
+	config.SetServerSideFlag(true)
 	connLogger.Info("ListenAndServe() initialization")
 
 	tlsConfig := &tls.Config{
@@ -149,6 +149,7 @@ func Do(req *http.Request) (*http.Response, error) {
 
 	connLogger := log.LoggerLgr.WithName(log.ConstConnManager)
 	identityLogger := log.LoggerLgr.WithName(log.ConstIdentityManager)
+	config.SetServerSideFlag(false)
 
 	connLogger.Info("client.Do() initialization")
 

--- a/identity/IdentityManager.go
+++ b/identity/IdentityManager.go
@@ -28,6 +28,16 @@ func VerifyIdentity(uri string) bool {
 	return false
 }
 
+func GetCurrentIdentity() (spiffeid.ID, error) {
+	tlsCert, tlsCertErr := GetCert()
+	if tlsCertErr == nil {
+		x509Cert, _ := x509.ParseCertificate(tlsCert.Certificate[0])
+		serverId, err := IDFromCert(x509Cert)
+		return serverId, err
+	}
+	return spiffeid.ID{}, tlsCertErr
+}
+
 // IDFromCert extracts the SPIFFE ID from the URI SAN of the provided
 // certificate. It will return an an error if the certificate does not have
 // exactly one URI SAN with a well-formed SPIFFE ID.

--- a/identity/IdentityManager.go
+++ b/identity/IdentityManager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/quicsec/quicsec/config"
 	"github.com/quicsec/quicsec/operations/log"
+	"github.com/quicsec/quicsec/spiffeid"
 )
 
 func VerifyIdentity(uri string) bool {
@@ -25,6 +26,19 @@ func VerifyIdentity(uri string) bool {
 	}
 
 	return false
+}
+
+// IDFromCert extracts the SPIFFE ID from the URI SAN of the provided
+// certificate. It will return an an error if the certificate does not have
+// exactly one URI SAN with a well-formed SPIFFE ID.
+func IDFromCert(cert *x509.Certificate) (spiffeid.ID, error) {
+	switch {
+	case len(cert.URIs) == 0:
+		return spiffeid.ID{}, errors.New("certificate contains no URI SAN")
+	case len(cert.URIs) > 1:
+		return spiffeid.ID{}, errors.New("certificate contains more than one URI SAN")
+	}
+	return spiffeid.FromURI(cert.URIs[0])
 }
 
 func GetCert() (*tls.Certificate, error) {

--- a/operations/OperationsManager.go
+++ b/operations/OperationsManager.go
@@ -1,11 +1,13 @@
 package operations
 
 import (
+	"crypto/x509"
 	"io"
 	"sync"
 
 	"github.com/quic-go/quic-go/logging"
 	"github.com/quicsec/quicsec/config"
+	"github.com/quicsec/quicsec/identity"
 	"github.com/quicsec/quicsec/operations/log"
 	"github.com/quicsec/quicsec/utils"
 )
@@ -59,6 +61,15 @@ func OperationsInit() (io.Writer, logging.Tracer) {
 
 		if len(tracers) > 0 {
 			tracer = logging.NewMultiplexedTracer(tracers...)
+		}
+
+		tlsCert, tlsCertErr := identity.GetCert()
+		if tlsCertErr == nil {
+			x509Cert, _ := x509.ParseCertificate(tlsCert.Certificate[0])
+			serverId, err := identity.IDFromCert(x509Cert)
+			if err == nil {
+				config.SetIdentity(serverId)
+			}
 		}
 	})
 

--- a/operations/OperationsManager.go
+++ b/operations/OperationsManager.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"crypto/x509"
 	"io"
 	"sync"
 
@@ -63,13 +62,9 @@ func OperationsInit() (io.Writer, logging.Tracer) {
 			tracer = logging.NewMultiplexedTracer(tracers...)
 		}
 
-		tlsCert, tlsCertErr := identity.GetCert()
-		if tlsCertErr == nil {
-			x509Cert, _ := x509.ParseCertificate(tlsCert.Certificate[0])
-			serverId, err := identity.IDFromCert(x509Cert)
-			if err == nil {
-				config.SetIdentity(serverId)
-			}
+		currentId, err := identity.GetCurrentIdentity()
+		if err == nil {
+			config.SetIdentity(currentId)
 		}
 	})
 

--- a/operations/metrics.go
+++ b/operations/metrics.go
@@ -21,32 +21,34 @@ import (
 )
 
 var (
-	bytesTransferred   *prometheus.CounterVec
-	packetsTransferred *prometheus.CounterVec
-	newConns           *prometheus.CounterVec
-	closedConns        *prometheus.CounterVec
-	sentPackets        *prometheus.CounterVec
-	rcvdPackets        *prometheus.CounterVec
-	bufferedPackets    *prometheus.CounterVec
-	droppedPackets     *prometheus.CounterVec
-	lostPackets        *prometheus.CounterVec
-	connErrors         *prometheus.CounterVec
-	HttpRequestsPath   *prometheus.CounterVec
-	HttpRequestsStatus *prometheus.CounterVec
+	bytesTransferred         *prometheus.CounterVec
+	packetsTransferred       *prometheus.CounterVec
+	newConns                 *prometheus.CounterVec
+	closedConns              *prometheus.CounterVec
+	sentPackets              *prometheus.CounterVec
+	rcvdPackets              *prometheus.CounterVec
+	bufferedPackets          *prometheus.CounterVec
+	droppedPackets           *prometheus.CounterVec
+	lostPackets              *prometheus.CounterVec
+	connErrors               *prometheus.CounterVec
+	HttpRequestsPathIdClient *prometheus.CounterVec
+	HttpRequestsPathIdServer *prometheus.CounterVec
+	AuthzConnectiontClientId *prometheus.CounterVec
+	AuthzConnectiontServerId *prometheus.CounterVec
 
-	HTTPHistogramAppProcess = prometheus.NewHistogram(
+	HTTPHistogramAppProcessId = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "http_request_application_process_latency",
-			Help:    "The application latency to process a HTTP request",
-			Buckets: prometheus.ExponentialBuckets(0.001, 1.25, 20), // starts at 1ms
-		})
+			Name:    "appedge_inbound_rq_latency",
+			Help:    "The application latency to process a HTTP request by tuple of identity",
+			Buckets: prometheus.ExponentialBuckets(0.001, 1.25, 20), // 1ms start
+		}, []string{"myId", "downstreamId"})
 
-	HTTPHistogramNetworkLatency = prometheus.NewHistogram(
+	HTTPHistogramNetworkLatencyId = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "http_request_network_latency",
-			Help:    "The network latency between the request and the response",
-			Buckets: prometheus.ExponentialBuckets(0.001, 1.25, 20), // starts at 1ms
-		})
+			Name:    "appedge_outbound_rq_latency",
+			Help:    "The network latency between the request and the response by tuple of identity",
+			Buckets: prometheus.ExponentialBuckets(0.001, 1.25, 20), // 1ms start
+		}, []string{"myId", "upstreamId"})
 )
 
 type aggregatingCollector struct {
@@ -221,29 +223,49 @@ func metricsInit() {
 		[]string{encLevel, "reason"},
 	)
 	prometheus.MustRegister(lostPackets)
-	HttpRequestsPath = prometheus.NewCounterVec(
+
+	HttpRequestsPathIdClient = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "http_request_path_counter",
+			Name: "appedge_outbound_rq_total",
 			Help: "HTTP requests counter by group (method, path and status)",
 		},
-		[]string{"instance", "method", "path", "status"},
+		[]string{"myId", "upstreamId", "instance", "method", "path", "status"},
 	)
-	prometheus.MustRegister(HttpRequestsPath)
-	HttpRequestsStatus = prometheus.NewCounterVec(
+	prometheus.MustRegister(HttpRequestsPathIdClient)
+
+	HttpRequestsPathIdServer = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "http_request_status_counter",
-			Help: "HTTP requests counter only by status",
+			Name: "appedge_inbound_rq_total",
+			Help: "HTTP requests counter by group (method, path and status)",
 		},
-		[]string{"status"},
+		[]string{"myId", "downstreamId", "instance", "method", "path", "status"},
 	)
-	prometheus.MustRegister(HttpRequestsStatus)
+	prometheus.MustRegister(HttpRequestsPathIdServer)
+
+	AuthzConnectiontServerId = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "appedge_inbound_cx_total",
+			Help: "Authorization counter by tuple of identity (server side)",
+		},
+		[]string{"myId", "downstreamId", "status"},
+	)
+	prometheus.MustRegister(AuthzConnectiontServerId)
+
+	AuthzConnectiontClientId = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "appedge_outbound_cx_total",
+			Help: "Authorization counter by tuple of identity (client side)",
+		},
+		[]string{"myId", "upstreamId", "status"},
+	)
+	prometheus.MustRegister(AuthzConnectiontClientId)
 
 	collector = newAggregatingCollector()
 	prometheus.MustRegister(collector)
 
-	prometheus.MustRegister(HTTPHistogramAppProcess)
+	prometheus.MustRegister(HTTPHistogramAppProcessId)
 
-	prometheus.MustRegister(HTTPHistogramNetworkLatency)
+	prometheus.MustRegister(HTTPHistogramNetworkLatencyId)
 
 	pFlag, pAddr := config.GetPrometheusHTTPConfig()
 	if pFlag {


### PR DESCRIPTION
- Each HTTP request now contains the peer Identity (upstream or downstream). This is possible thanks to the TLS ConnectionState inside the http request (extract peer certificate (SAN URI))
- rename some metrics variables
- create prometheus metrics based on tuple of identity

Features of #38 #39 