### PR TITLE
Metrics should be incremented only when metrics is enabled.

### DIFF
--- a/auth/authManager.go
+++ b/auth/authManager.go
@@ -168,21 +168,23 @@ func CustomVerifyPeerCertificate(rawCerts [][]byte, verifiedChains [][]*x509.Cer
 		rv := identity.VerifyIdentity(uri.String())
 		if rv {
 			authLogger.Info("verify peer certificate", "authorized", "yes", "URI", uri.String())
-			if config.GetServerSideFlag() {
-				operations.AuthzConnectiontServerId.WithLabelValues(config.GetIdentity().String(), uri.String(), "authorized").Inc()
-			} else {
-				operations.AuthzConnectiontClientId.WithLabelValues(config.GetIdentity().String(), uri.String(), "authorized").Inc()
+			if config.GetMetricsEnabled() {
+				if config.GetServerSideFlag() {
+					operations.AuthzConnectiontServerId.WithLabelValues(config.GetIdentity().String(), uri.String(), "authorized").Inc()
+				} else {
+					operations.AuthzConnectiontClientId.WithLabelValues(config.GetIdentity().String(), uri.String(), "authorized").Inc()
+				}
 			}
 			return nil
 		} else {
-			if config.GetServerSideFlag() {
-				operations.AuthzConnectiontServerId.WithLabelValues(config.GetIdentity().String(), uri.String(), "unauthorized").Inc()
-			} else {
-				operations.AuthzConnectiontClientId.WithLabelValues(config.GetIdentity().String(), uri.String(), "unauthorized").Inc()
+			if config.GetMetricsEnabled() {
+				if config.GetServerSideFlag() {
+					operations.AuthzConnectiontServerId.WithLabelValues(config.GetIdentity().String(), uri.String(), "unauthorized").Inc()
+				} else {
+					operations.AuthzConnectiontClientId.WithLabelValues(config.GetIdentity().String(), uri.String(), "unauthorized").Inc()
+				}
 			}
-
 			authLogger.Info("verify peer certificate", "authorized", "no", "URI", uri.String())
-
 		}
 	}
 

--- a/config/configManager.go
+++ b/config/configManager.go
@@ -183,6 +183,10 @@ func SetServerSideFlag(f bool) {
 	globalConfig.Local.ServerSideFlag = f
 }
 
+func GetMetricsEnabled() bool {
+	return globalConfig.Metrics.Enable
+}
+
 func (c Config) ShowConfig() {
 	fmt.Printf("Init configuration\n")
 

--- a/operations/httplog/httpLog.go
+++ b/operations/httplog/httpLog.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	//"github.com/quicsec/quicsec/operations"
+	"github.com/quicsec/quicsec/operations"
 
 	"github.com/quicsec/quicsec/config"
 	"github.com/quicsec/quicsec/identity"
@@ -85,12 +85,14 @@ func (lrt LoggingRoundTripper) RoundTrip(r *http.Request) (res *http.Response, e
 			size = int(res.ContentLength)
 		}
 
-		// Prometheus metrics for HTTP
-		if len(res.TLS.PeerCertificates) > 0 {
-			serverId, err := identity.IDFromCert(res.TLS.PeerCertificates[0])
-			if err == nil {
-				operations.HttpRequestsPathIdClient.WithLabelValues(config.GetIdentity().String(), serverId.String(), r.Host, r.Method, r.URL.RequestURI(), strconv.Itoa(res.StatusCode)).Inc()
-				operations.HTTPHistogramNetworkLatencyId.WithLabelValues(config.GetIdentity().String(), serverId.String()).Observe(duration.Seconds())
+		//Prometheus metrics for HTTP
+		if config.GetMetricsEnabled() {
+			if len(res.TLS.PeerCertificates) > 0 {
+				serverId, err := identity.IDFromCert(res.TLS.PeerCertificates[0])
+				if err == nil {
+					operations.HttpRequestsPathIdClient.WithLabelValues(config.GetIdentity().String(), serverId.String(), r.Host, r.Method, r.URL.RequestURI(), strconv.Itoa(res.StatusCode)).Inc()
+					operations.HTTPHistogramNetworkLatencyId.WithLabelValues(config.GetIdentity().String(), serverId.String()).Observe(duration.Seconds())
+				}
 			}
 		}
 


### PR DESCRIPTION
In some places the metrics are incremented without checking if the configuration has metrics enabled. When not enabled (e.g.  QUICSEC_METRICS_ENABLE="0" ) increment the metrics cause the software to crash because the metrics counter is no initialized.

We have created a get function to check if metrics are enables and then only inclement when enabled.