### PR TITLE
cert-manager-csi-spiffe-doc update to include instructions to install on openshift

### DIFF
--- a/docs/cert-manager/CERT-MANAGER-CSI-SPIFFE.md
+++ b/docs/cert-manager/CERT-MANAGER-CSI-SPIFFE.md
@@ -1,5 +1,5 @@
 
-## Installing Cert-Manager and Cert-manager-csi-spiffe
+## Installing Cert-manager-CSI-SPIFFE
 
 1. Install cert-manager with approver disabled in the controller.
 
@@ -14,25 +14,34 @@ helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager \
 
 2. Deploy clusterIssuer to issue certificates via cert-manager-csi-spiffe, and approve 
 
-Install cert-manager-csi-spiffe clusterIssuer and approve. If you haven't previously integrated cert-manager with kubectl, you might need to [add](https://cert-manager.io/v1.5-docs/usage/kubectl-plugin/#installation) the cert-manager plugin to kubectl. Alternatively, install _cmctl_ according to cert-manager docs.
+Install cert-manager-csi-spiffe clusterIssuer and approve certificateRequest. You might need to install [cmctl](https://cert-manager.io/docs/reference/cmctl/).
 ```
-kubectl apply -f kubernetes-manifests/cert-manager/10-csi-spiffe-cluster-issuer.yaml
-kubectl cert-manager approve -n cert-manager $(kubectl get cr -n cert-manager -ojsonpath='{.items[0].metadata.name}')
+kubectl apply -f kubernetes-manifests/cert-manager-csi-spiffe/10-csi-spiffe-cluster-issuer.yaml
+cmctl approve -n cert-manager $(kubectl get cr -n cert-manager -ojsonpath='{.items[0].metadata.name}')
 ```
 
-3. Sign Issuers for optional components that rely on cert-manager.
+3. **Optional** Install any optional components that might rely on cert-manager (e.g., aws-load-balancer-controller, etc.), and sign any created certificateRequests.
 
 If you have any other optional components that rely on cert-manager, now is a good time to deploy them and approve cert-manager issuers/clusterissuers for them. For example, the step below illustrates the process to deploy the AWS Load Balancer Controller for Kubernetes, which relies on cert-manager.
 
 ```
-# kubectl apply -f infra/aws-load-balancer-controller-v2_4_4_full.yaml
-# kubectl cert-manager approve -n kube-system $(kubectl get cr -n kube-system -ojsonpath='{.items[0].metadata.name}')
+kubectl apply -f infra/aws-load-balancer-controller-v2_4_4_full.yaml
+kubectl cert-manager approve -n kube-system $(kubectl get cr -n kube-system -ojsonpath='{.items[0].metadata.name}')
 ```
 
 4. Install cert-manager-csi-spiffe
 
-Pay attention to the trust domain used below - this will be embedded within generated spiffeIDs and used within Auth rules.
+If deploying on OpenShift, ensure that the appropriate security context constraints are mapped to the csi-driver-spiffe service account. For other kubernetes platforms besides OpenShift, simply deploy the csi-driver-spiffe as described below.
+
+
 ```
+# OPENSHIFT ONLY
+# Security Context Constraints required for serviceAccount used by cert-manager csi-driver-spiffe daemonset
+
+oc adm policy add-scc-to-user privileged -n cert-manager -z cert-manager-csi-driver-spiffe
+
+# ALL PLATFORMS - Deploy csi-driver-spiffe using helm chart
+
 helm upgrade -i -n cert-manager cert-manager-csi-driver-spiffe jetstack/cert-manager-csi-driver-spiffe --wait \
     --set "app.logLevel=1" --set "app.trustDomain=cluster.local"  \
     --set "app.approver.signerName=clusterissuers.cert-manager.io/csi-driver-spiffe-ca"  \
@@ -42,5 +51,12 @@ helm upgrade -i -n cert-manager cert-manager-csi-driver-spiffe jetstack/cert-man
     --set "app.driver.volumeMounts[0].name=root-cas" \
     --set "app.driver.volumeMounts[0].mountPath=/var/run/secrets/cert-manager-csi-driver-spiffe" \
     --set "app.driver.sourceCABundle=/var/run/secrets/cert-manager-csi-driver-spiffe/ca.crt"
+```
+
+
+5. (OpenShift ONLY) Label CSIDriver
+
+```
+oc label CSIDriver spiffe.csi.cert-manager.io security.openshift.io/csi-ephemeral-volume-profile=restricted
 ```
 

--- a/docs/demos/quickstart.md
+++ b/docs/demos/quickstart.md
@@ -9,7 +9,7 @@ QuicSec functions as middleware for your application. The steps involved in adop
 
 - Optionally, [Configuring](https://quicsec.io/docs/configure) non-default values for configuration if necessary.
 
-- [Using](https://quicsec.io/docs/use) QuicSec and benefiting from it for various use cases.
+- [Using](https://quicsec.io/docs/use) QuicSec and benefiting from it for various use cases. 
 
 
 ## [Demo Example](https://quicsec.io/docs/example-bookstore): Bookstore Microservice Applications
@@ -22,7 +22,11 @@ Following the [example](https://quicsec.io/docs/example-bookstore) will provide 
 
 * Automatically taking care of identity and certificate management workflows
 
-* Security with Identity-based TLS or mTLS policies.
+* Security with Identity-based TLS or mTLS policies. 
+
+* Optionally other security features can be enabled via plugins, including client authentication (via Auth0/Okta or other OIDC platform integration) using JWT workflows, Policy Authorization (using OPA), WAAP/WAF for defense-in-depth, etc..
+
+* QuicSec leverages the ext_authz framework to enable additional plugins (thereby allowing any of the security plugins enabled for the envoy proxy, but now natively into the app within the http layer and without needing a proxy).
 
 * Observability for the application with automatic logs and metrics.
 

--- a/docs/observability/observability-dashboards.md
+++ b/docs/observability/observability-dashboards.md
@@ -1,0 +1,38 @@
+# AppEdge Automatic Observability 
+
+Automatic monitoring, logging, dashboarding and alerting is enabled for apps. Templates are generated for Prometheus, Loki, Alertmanager and Grafana to provide a simple batteries-included experience, but can be integrated with your organizational systems for observability.
+
+
+# Observability Addon Deployment
+
+Deploying the manifests below pulls down the standard upstream versions of Prometheus, Loki and Grafana from their upstream repositories.
+
+```
+kubectl apply -f --server-side kubernetes-manifests/metrics/operator
+kubectl apply -f kubernetes-manifests/metrics/
+```
+
+Grafana, Prometheus and Loki can now be accessed via port-forward. Alternatively, an ingressgateway can be deployed for access (by **kubectl apply -f contour/60-ingress-grafana-prometheus-loki.yaml**)
+
+```
+kubectl port-forward -n qm-monitoring deploy/grafana 3000:3000 &
+kubectl port-forward -n qm-monitoring deploy/loki 3100:3100 &
+kubectl port-forward -n qm-monitoring prometheus-prometheus-0 9090 &
+```
+If an ingressgateway was used for these as mentioned above, then create a hosts (e.g., /etc/hosts) entry on your local system creating hostnames (qm-prometheus.com, qm-grafana.com) pointing to your gateway node IP. Then access Grafana and Prometheus from http://qm-grafana.com/ and http://qm-prometheus.com. 
+
+If not, and you are using a port-forward, then the respective dashboards can be accessed at http://localhost:3000/, http://localhost:3100/ and https://localhost:9090/ - however, in this case the links within your grafana dashboard might not work.
+
+## Dashboard (Grafana)
+
+![QM Grafana Service Map](/images/desktop/quicmesh-service-map.png)
+
+The Dashboard can be accessed using qm-grafana.com (or the port specified in the port-forward above if an ingressgateway was not deployed). Login using the admin:admin credentials, and browse available dashboards to find the the Service Map and the Downstreams Dashboard.
+
+Note that both these dashboards dynamically update by choosing the values from the dropdown selectors on the top row.
+
+
+![QM Grafana Downstreams Dashboard](/images/desktop/quicmesh-downstreams-dashboard.png)
+
+
+

--- a/docs/observability/observability-logging.md
+++ b/docs/observability/observability-logging.md
@@ -1,0 +1,33 @@
+# AppEdge Automatic Observability 
+
+Automatic monitoring, logging, dashboarding and alerting is enabled for apps. Templates are generated for Prometheus, Loki, Alertmanager and Grafana to provide a simple batteries-included experience, but can be integrated with your organizational systems for observability.
+
+
+# Observability Addon Deployment
+
+Deploying the manifests below pulls down the standard upstream versions of Prometheus, Loki and Grafana from their upstream repositories.
+
+```
+kubectl apply -f --server-side kubernetes-manifests/metrics/operator
+kubectl apply -f kubernetes-manifests/metrics/
+```
+
+Grafana, Prometheus and Loki can now be accessed via port-forward. Alternatively, an ingressgateway can be deployed for access (by **kubectl apply -f contour/60-ingress-grafana-prometheus-loki.yaml**)
+
+```
+kubectl port-forward -n qm-monitoring deploy/grafana 3000:3000 &
+kubectl port-forward -n qm-monitoring deploy/loki 3100:3100 &
+kubectl port-forward -n qm-monitoring prometheus-prometheus-0 9090 &
+```
+If an ingressgateway was used for these as mentioned above, then create a hosts (e.g., /etc/hosts) entry on your local system creating hostnames (qm-prometheus.com, qm-grafana.com) pointing to your gateway node IP. Then access Grafana and Prometheus from http://qm-grafana.com/ and http://qm-prometheus.com. 
+
+If not, and you are using a port-forward, then the respective dashboards can be accessed at http://localhost:3000/, http://localhost:3100/ and https://localhost:9090/ - however, in this case the links within your grafana dashboard might not work.
+
+## Logs (Loki)
+
+![Loki logs](/images/desktop/quicmesh-loki-logs.png)
+
+Accessing HTTP Logs on behalf of your app can be done by visiting grafana (localhost:3000 when using the port-forward step described above), and going to the Explore tab on the left bar. 
+
+
+

--- a/docs/observability/observability-monitoring.md
+++ b/docs/observability/observability-monitoring.md
@@ -1,0 +1,33 @@
+# AppEdge Automatic Observability 
+
+Automatic monitoring, logging, dashboarding and alerting is enabled for apps. Templates are generated for Prometheus, Loki, Alertmanager and Grafana to provide a simple batteries-included experience, but can be integrated with your organizational systems for observability.
+
+
+# Observability Addon Deployment
+
+Deploying the manifests below pulls down the standard upstream versions of Prometheus, Loki and Grafana from their upstream repositories.
+
+```
+kubectl apply -f --server-side kubernetes-manifests/metrics/operator
+kubectl apply -f kubernetes-manifests/metrics/
+```
+
+Grafana, Prometheus and Loki can now be accessed via port-forward. Alternatively, an ingressgateway can be deployed for access (by **kubectl apply -f contour/60-ingress-grafana-prometheus-loki.yaml**)
+
+```
+kubectl port-forward -n qm-monitoring deploy/grafana 3000:3000 &
+kubectl port-forward -n qm-monitoring deploy/loki 3100:3100 &
+kubectl port-forward -n qm-monitoring prometheus-prometheus-0 9090 &
+```
+If an ingressgateway was used for these as mentioned above, then create a hosts (e.g., /etc/hosts) entry on your local system creating hostnames (qm-prometheus.com, qm-grafana.com) pointing to your gateway node IP. Then access Grafana and Prometheus from http://qm-grafana.com/ and http://qm-prometheus.com. 
+
+If not, and you are using a port-forward, then the respective dashboards can be accessed at http://localhost:3000/, http://localhost:3100/ and https://localhost:9090/ - however, in this case the links within your grafana dashboard might not work.
+
+## Metrics (Prometheus)
+
+Prometheus telemetry is collected automatically by QuicSec, and can be scraped by Prometheus or other telemetry collectors. The port on which metrics can be scraped is configured by QUICSEC_METRICS_ENABLE and QUICSEC_PROMETHEUS_BIND as outlined in the [configuration parameters](/docs/env-vars).
+
+![Prometheus Monitoring](/images/desktop/quicmesh-prometheus-monitoring.png)
+
+
+

--- a/docs/security/security-jwt.md
+++ b/docs/security/security-jwt.md
@@ -1,0 +1,57 @@
+# Security: JWT User Identity
+
+_NOTE: This page provides documentation for the JWT and Client Identity validation which is a pull request pending approval and merging into QuicSec. Integration via OIDC platforms like Auth0/Okta are enabled with this capability, enabling transparent user authentication workflows on behalf of the app.
+
+## Overview: JWT Assignment (via OIDC) and Authorization (Claims Validation)
+
+User Identity workflows (using JWT) can be enabled in a single step on behalf of the applications. The JWT assignment (via OIDC) and claims authorization workflows are implemented as a plugin allowing for dynamic addition when enabled. The notable capabilities implemented by the plugin include:
+
+* OIDC Redirection: Requests missing an Authorization header are redirected via OIDC to a configured authorization service provider (e.g., Auth0/Okta).
+
+* Claims Authorization: Individual transactions will be allowed or denied based on policies matching on the audience and scope embedded in the token
+
+## Architecture
+
+
+![User Identity and JWT Auth Architecture](/images/desktop/jwt-authorization.png)
+
+When enabled, the User Identity / JWT workflow redirects all inbound http requests lacking a jwt authorization header to the configured Authorization service. Similarly, any clients whose requests successfully complete authorization and are redirected back to the redirection uri will have the issuer identity verified, and further authorization of the claims and scope for the resource being accessed will be authorized, as illustrated in the examples below. Authorization policies can either be via built-in Policy resources or via external authrization via plugins like OPA.
+
+
+
+## Scenarios
+
+The different scenarios to consider when creating User authentication (JWT) policies are illustrated with the help of the architecture diagram above.
+
+The types of client accesses to consider when building policies:
+
+* 1. Configure Authorization Provider (e.g., Auth0 / Okta) for this application, providing a redirection url during configuration and receiving a client secret.
+
+* 2. Clients that haven't previously authenticated with the authorization service to receive a jwt. In this case, when the client application attempts to access the App, it will be redirected to the Authorization service via OIDC. Once the client has successfully authenticated with the Auth service, it will be assigned a jwt with embedded issuer, claims and scope, and redirected to the redirection uri via OIDC in order to access the resource previously requested.
+
+* 3. Clients that have previously authenticated with the authorization service and initiate the requet with an authorization header containing a jwt. The issuer signature within the jwt is verified and the claims and scope extracted and authorized for the resource being accessed. This authorization can either be done with built-in policies, or via external authorization plugins (e.g., Open Policy Agent/OPA) using policy schema defined for the plugin (e.g., OPA rego).
+
+## Audit
+
+The built-in observability features provide detailed identity-enriched logs, telemetry and dashboards, as described in the [Observability](/docs/observability-dashboards) docs.
+
+
+For example, logs listing the authorized or unauthorized identities accessing the application can be listed as below:
+``` 
+$ kubectl logs -n bookstore -l "app=AppName" -f |grep AUTHORIZED
+16:35:00 [[QM]] WARN Ext_AuthZ/OPA "JWT Claims <CLAIM> not Authorized for Scope <SCOPE>" UNAUTHORIZED policy=extauth-opa
+16:35:01 [[QM]] WARN Unknown Identity UNAUTHORIZED policy=default
+```
+
+## ASDEX Score
+
+![Dashboard with mTLS Telemetry](/images/desktop/mtls-asdex-dashboard.png)
+
+The product computes a simple **Application Security Index (ASDEX)** score for applications within the observability metrics and dashboards. This is a simple measure of how many of the inbound requests accessing the app are considered to be less secured or better secured relative to the total number of inbound accesses. The value is a number between 0.00 and 1.00. A lower value indicates that a greater proportion of inbound transactions are from clients lacking identity, policy, additional security defenses, or a combination of these. 
+
+The desired objective for apps would be to get as close to 1.00 as possible. While a score of say 0.99 is not an absolute guarantee of perfect security, it provides some assurance that inbound transactions are associated with an attested client workload identity, is governed by a policy vetted by the organization, and has additional security defense-in-depth controls that have analysed the connection.
+
+The ASDEX score is highlighted throughout the dashboards as well, providing an at-a-glance view of the percentage of inbound requests to an application that can be considered to be relatively suspicious or risky.
+
+
+

--- a/docs/security/security-mtls.md
+++ b/docs/security/security-mtls.md
@@ -1,0 +1,67 @@
+# Security: Mutual TLS
+
+
+Mutual TLS is enabled in a single step, which can be further automated to allow for zero-config security. 
+
+
+The important element to enable mTLS is the identity of the workload, and it is enabled with the help of pluggable solutions like SPIFFE and cert-manager. Identity managemement (including cert provisioning/attestation, hourly rotation and validation) is completely automated. For mTLS, peer certificates are automatically validated as governed by policy.
+
+
+## Architecture
+
+The key ingredients for zero-trust security with mTLS are Identity, AuthN/Z, Encryption and Audit. These are all enabled in a single step, which can be further automated for zero-config security which follows the workload instantly across any platform, and independent of infrastructure. Enforcement is consistent across all appEdge bindings, including native/proxyless HTTP apps.
+
+* Identity: enabled with the help of pluggable solutions like SPIFFE and cert-manager. Identity managemement (including cert provisioning/attestation, hourly rotation and validation) is completely automated.
+
+* AuthN/Z: Policy resources guide whether a connection to a given peer is authorized. The solution automates requesting and verification of the peer certificate, and enforcing the policy claims aligned within the embedded identity. Policies can either leverage peer identity via annotations of the application deployment resource, or by using Identity Sets (idSets) providing a scalable way of managing identity-based Auth rules.
+
+* Encryption: Automatically enabled for all flows. Even if mutual TLS is disabled, the solution will still enable one-way TLS where traffic is encrypted even if policy allows for open access from peers (including peers lacking identity).
+
+* Audit: Metrics, logging and traces with identity-enriched metadata is collected for all flows and transactions. The [Observability](/docs/observability-dashboards) docs provide more background on audit and visibility with the build-in observability tools, or integration with existing SIEM/SOAR and other security tools used.
+
+![Mutual TLS Architecture](/images/desktop/mTLS-scenarios.png)
+
+
+No access to the client side is required to enable mTLS on a service. If a client has an existing workload x509 identity, the existing identity is used for mTLS policy. If the client lacks a workload identity, policy determines whether one-way TLS will be used to allow access from that client, or if mutual TLS will deny the client.
+
+
+## Scenarios
+
+The different scenarios to consider when building identity-defined mTLS policies are illustrated with the help of the architecture diagram above.
+
+The types of client accesses to consider when building policies:
+
+* 1. Clients that lack attested x509 identity. These can only be allowed if policy disables mTLS.
+
+* 2. Clients that have an attested x509 identity, but are not allowed in policy. 
+
+* 3. Clients that have an attested x509 identity, and are members of an allowed identity. This is the recommended option to ensure identity-defined security across the organization. Client-C in the architecture diagram above.
+
+
+## Audit
+
+The built-in observability features provide detailed identity-enriched logs, telemetry and dashboards, these can be integrated with existing Audit, GRC and SIEM platforms. 
+
+For example, logs listing the authorized or unauthorized identities accessing the application can be listed as below:
+``` 
+$ kubectl logs -n bookstore -l "app=AppName" -f |grep AUTHORIZED
+16:35:00 [[QM]] WARN SPIFFE "spiffe://cluster.local/ns/teamRed-NS/sa/team-Red-clientapp-R" UNAUTHORIZED policy=default
+16:35:01 [[QM]] WARN SPIFFE "spiffe://cluster.local/ns/teamC-NS/sa/team-C-clientapp-Z" AUTHORIZED policy=strict
+16:35:01 [[QM]] WARN Unknown Identity UNAUTHORIZED policy=default
+```
+
+If using the native, proxyless HTTP application bindings instead, then the audit logs will be provided via the application logs directly.
+
+## ASDEX Score
+
+![Dashboard with mTLS Telemetry](/images/desktop/mtls-asdex-dashboard.png)
+
+The product computes a simple **Application Security Index (ASDEX)** score for applications within the observability metrics and dashboards. This is a simple measure of how many of the inbound requests accessing the app are considered to be less secured or better secured relative to the total number of inbound accesses. The value is a number between 0.00 and 1.00. A lower value indicates that a greater proportion of inbound transactions are from clients lacking identity, policy, additional security defenses, or a combination of these. 
+
+The desired objective for apps would be to get as close to 1.00 as possible. While a score of say 0.99 is not an absolute guarantee of perfect security, it provides some assurance that inbound transactions are associated with an attested client workload identity, is governed by a policy vetted by the organization, and has additional security defense-in-depth controls that have analysed the connection.
+
+The ASDEX score is highlighted throughout the dashboards as well, providing an at-a-glance view of the percentage of inbound requests to an application that can be considered to be relatively suspicious or risky.
+
+
+
+

--- a/docs/security/security-opa.md
+++ b/docs/security/security-opa.md
@@ -1,0 +1,40 @@
+# Security: Open Policy Agent (OPA) Filter
+
+## Overview
+
+Open Policy Agent (OPA) can be used for flexible and dynamic policy authorization, and can be included as part of the AppEdge filter chains on behalf of the application. 
+
+Any existing ext_authz filter can be attached to the AppEdge filter chain, and the example below illustrates how OPA authorization can be attached as an AppEdge filter, enabling any dynamic rego-based policy to be used together with the OPA authorizer.
+
+## Architecture
+
+![Open Policy Agent / OPA Filter](/images/desktop/opa-architecture.png)
+
+
+
+
+
+## Audit
+
+The built-in observability features provide detailed identity-enriched logs, telemetry and dashboards, as described in the [Observability](/docs/observability-dashboards) docs.
+
+
+For example, logs listing the authorized or unauthorized identities accessing the application can be listed as below:
+``` 
+$ kubectl logs -n bookstore -l "app=AppName" -f |grep AUTHORIZED
+16:35:00 [[QM]] WARN Ext_AuthZ/OPA "JWT Claims <CLAIM> not Authorized for Scope <SCOPE>" UNAUTHORIZED policy=extauth-opa
+16:35:01 [[QM]] WARN Unknown Identity UNAUTHORIZED policy=default
+```
+
+## ASDEX Score
+
+![Dashboard with mTLS Telemetry](/images/desktop/mtls-asdex-dashboard.png)
+
+The product computes a simple **Application Security Index (ASDEX)** score for applications within the observability metrics and dashboards. This is a simple measure of how many of the inbound requests accessing the app are considered to be less secured or better secured relative to the total number of inbound accesses. The value is a number between 0.00 and 1.00. A lower value indicates that a greater proportion of inbound transactions are from clients lacking identity, policy, additional security defenses, or a combination of these. 
+
+The desired objective for apps would be to get as close to 1.00 as possible. While a score of say 0.99 is not an absolute guarantee of perfect security, it provides some assurance that inbound transactions are associated with an attested client workload identity, is governed by a policy vetted by the organization, and has additional security defense-in-depth controls that have analysed the connection.
+
+The ASDEX score is highlighted throughout the dashboards as well, providing an at-a-glance view of the percentage of inbound requests to an application that can be considered to be relatively suspicious or risky.
+
+
+

--- a/docs/security/security-waap.md
+++ b/docs/security/security-waap.md
@@ -1,0 +1,38 @@
+# Security: Web App and API Protection (WAAP) and Web App Firewall (WAF)
+
+## Overview
+
+Identity-defined defense-in-depth security can be enabled for apps by attaching a WAAP/WAF filter as part of the AppEdge filter chains. 
+
+## Architecture
+
+![Web App and API Protection / WAF Architecture](/images/desktop/waap-architecture.png)
+
+
+
+
+
+## Audit
+
+The built-in observability features provide detailed identity-enriched logs, telemetry and dashboards, as described in the [Observability](/docs/observability-dashboards) docs.
+
+
+For example, logs listing the authorized or unauthorized identities accessing the application can be listed as below:
+``` 
+$ kubectl logs -n bookstore -l "app=bookstore" -f |grep AUTHORIZED
+16:35:00 [[QM]] WARN Ext_AuthZ/OPA "JWT Claims <CLAIM> not Authorized for Scope <SCOPE>" UNAUTHORIZED policy=extauth-opa
+16:35:01 [[QM]] WARN Unknown Identity UNAUTHORIZED policy=default
+```
+
+## ASDEX Score
+
+![Dashboard with mTLS Telemetry](/images/desktop/mtls-asdex-dashboard.png)
+
+The product computes a simple **Application Security Index (ASDEX)** score for applications within the observability metrics and dashboards. This is a simple measure of how many of the inbound requests accessing the app are considered to be less secured or better secured relative to the total number of inbound accesses. The value is a number between 0.00 and 1.00. A lower value indicates that a greater proportion of inbound transactions are from clients lacking identity, policy, additional security defenses, or a combination of these. 
+
+The desired objective for apps would be to get as close to 1.00 as possible. While a score of say 0.99 is not an absolute guarantee of perfect security, it provides some assurance that inbound transactions are associated with an attested client workload identity, is governed by a policy vetted by the organization, and has additional security defense-in-depth controls that have analysed the connection.
+
+The ASDEX score is highlighted throughout the dashboards as well, providing an at-a-glance view of the percentage of inbound requests to an application that can be considered to be relatively suspicious or risky.
+
+
+


### PR DESCRIPTION
1. Updated cert-manager CSI-SPIFFE-Driver installation to include instructions to install on OpenShift
2. Updated observability (Metrics, Logging, Dashboards) and security (mTLS, JWT/Auth0-Okta, Waap/WAF and OPA policy) documentation